### PR TITLE
Run init in the beginning of npm run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "deploy": "devvit upload",
-    "dev": "dotenv -e .env -- devvit playtest",
+    "dev": "npx devvit@next init && dotenv -e .env -- devvit playtest",
     "login": "devvit login",
     "launch": "devvit publish",
     "type-check": "tsc --build"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "deploy": "devvit upload",
-    "dev": "npx devvit@next init && dotenv -e .env -- devvit playtest",
+    "dev": "devvit init && dotenv -e .env -- devvit playtest",
     "login": "devvit login",
     "launch": "devvit publish",
     "type-check": "tsc --build"


### PR DESCRIPTION
## 💸 TL;DR
Add `devvit init` as step in `npm run dev`. `init` is a no-op if the app is already initialized. This will make npm run dev work in Bolt from the get go.
